### PR TITLE
Rendre la recherche d'affiliation insensible à la casse

### DIFF
--- a/src/rnsr.js
+++ b/src/rnsr.js
@@ -1,6 +1,6 @@
 import { promises } from 'fs';
 import xmlParser from 'fast-xml-parser';
-import { includesLowerCase } from './strings';
+import { includesLowerCase, includesLowerCaseArray } from './strings';
 
 /**
  * @typedef {Object<string, any>} RepNatStrRech
@@ -62,10 +62,11 @@ const hasNumero = (address, etabAssocs) => etabAssocs[0] && etabAssocs.some(
 const followsNumeroLabel = (tokens, etabAssocs) => etabAssocs[0]
     && etabAssocs.some(
         (etabAssoc) => {
+            const lowerCaseTokens = tokens.map((t) => t.toLowerCase());
             const { label, numero } = etabAssoc;
-            if (tokens.includes(`${label}${numero}`)) return true;
-            const labelIndex = tokens.indexOf(label);
-            const numeroIndex = tokens.indexOf(String(numero));
+            if (includesLowerCaseArray(tokens, `${label}${numero}`)) return true;
+            const labelIndex = lowerCaseTokens.indexOf(label.toLowerCase());
+            const numeroIndex = lowerCaseTokens.indexOf(String(numero));
             if (labelIndex === -1) return false;
             if (numeroIndex === -1) return false;
             if (numeroIndex < labelIndex) return false;

--- a/src/rnsr.js
+++ b/src/rnsr.js
@@ -1,5 +1,6 @@
 import { promises } from 'fs';
 import xmlParser from 'fast-xml-parser';
+import { includesLowerCase } from './strings';
 
 /**
  * @typedef {Object<string, any>} RepNatStrRech
@@ -46,10 +47,10 @@ import xmlParser from 'fast-xml-parser';
  */
 
 const hasLabel = (address, etabAssocs) => etabAssocs[0] && etabAssocs.some(
-    (etabAssoc) => address.includes(etabAssoc.label || '**'),
+    (etabAssoc) => includesLowerCase(address, etabAssoc.label || '**'),
 );
 const hasNumero = (address, etabAssocs) => etabAssocs[0] && etabAssocs.some(
-    (etabAssoc) => address.includes(String(etabAssoc.numero) || '**'),
+    (etabAssoc) => includesLowerCase(address, String(etabAssoc.numero) || '**'),
 );
 /**
  * Say if numero follows label (optionnally with one token between both, or
@@ -73,8 +74,8 @@ const followsNumeroLabel = (tokens, etabAssocs) => etabAssocs[0]
         },
     );
 const hasPostalAddress = (address, structure) => (
-    address.includes(structure.ville_postale || '**')
-    || address.includes(String(structure.code_postal) || '**')
+    includesLowerCase(address, structure.ville_postale || '**')
+    || includesLowerCase(address, String(structure.code_postal) || '**')
 );
 
 /**
@@ -85,7 +86,7 @@ const hasPostalAddress = (address, structure) => (
  * @param {Structure} structure
  * @returns {boolean}
  */
-const hasIntitule = (address, structure) => address.includes(structure.intitule || '**');
+const hasIntitule = (address, structure) => includesLowerCase(address, structure.intitule || '**');
 
 /**
  * Say if the `structure` is in `address` according to the presence of sigle.
@@ -94,7 +95,7 @@ const hasIntitule = (address, structure) => address.includes(structure.intitule 
  * @param {Structure} structure
  * @returns {boolean}
  */
-const hasSigle = (address, structure) => address.includes(structure.sigle || '**');
+const hasSigle = (address, structure) => includesLowerCase(address, structure.sigle || '**');
 
 /**
  * Check that for at least one of the tutelles (`structure.etabAssoc.*.etab`):
@@ -117,8 +118,8 @@ const hasTutelle = (address, structure) => {
             && address.includes(etab.libelle || '**')) {
             return true;
         }
-        if (address.includes(etab.sigle || '**')
-            || address.includes(etab.libelle || '**')) {
+        if (includesLowerCase(address, etab.sigle || '**')
+            || includesLowerCase(address, etab.libelle || '**')) {
             return true;
         }
         return keep;

--- a/src/strings.js
+++ b/src/strings.js
@@ -7,3 +7,16 @@
 export const includesLowerCase = (haystack, needle) => {
     return haystack.toLowerCase().includes(needle.toLowerCase());
 };
+
+/**
+ * Check whether the `haystack` array lowercase elements includes the lowercase of `needle`.
+ * @param {string[]} haystack
+ * @param {string} needle
+ * @returns {boolean}
+ */
+export const includesLowerCaseArray = (haystack, needle) => {
+    const lowerCaseNeedle = needle.toLowerCase();
+    return haystack
+        .map((e) => e.toLowerCase())
+        .includes(lowerCaseNeedle);
+};

--- a/src/strings.js
+++ b/src/strings.js
@@ -1,0 +1,9 @@
+/**
+ * Check whether the lowercase of `haystack` includes the lowercase of `needle`.
+ * @param {string} haystack
+ * @param {string} needle
+ * @returns {boolean}
+ */
+export const includesLowerCase = (haystack, needle) => {
+    return haystack.toLowerCase().includes(needle.toLowerCase());
+};

--- a/test/affAlign.spec.js
+++ b/test/affAlign.spec.js
@@ -103,6 +103,39 @@ describe('co-aff-align', () => {
                 });
         });
 
+        it('should find the conditorRnsr even in lowercase', (done) => {
+            let res = [];
+            from([{
+                authors: [{
+                    affiliations: [{
+                        address: 'gdr 2989 université versailles saint-quentin-en-yvelines, 63009',
+                    }],
+                }],
+            }, {
+                authors: [{
+                    affiliations: [{
+                        address: 'Introuvable',
+                    }],
+                }],
+            }])
+                .pipe(ezs('affAlign'))
+                .on('data', (data) => {
+                    res = [...res, data];
+                })
+                .on('end', () => {
+                    expect(res).toHaveLength(2);
+                    expect(res[0]).toEqual({
+                        authors: [{
+                            affiliations: [{
+                                address: 'gdr 2989 université versailles saint-quentin-en-yvelines, 63009',
+                                conditorRnsr: ['200619958X'],
+                            }],
+                        }],
+                    });
+                    done();
+                });
+        });
+
         it('should not find the conditorRnsr with only a label', (done) => {
             let res = [];
             from([{
@@ -333,6 +366,33 @@ describe('co-aff-align', () => {
                     done();
                 });
         });
+
+        it('should find the conditorRnsr in lowercase', (done) => {
+            let res = [];
+            from([{
+                authors: [{
+                    affiliations: [{
+                        address: 'irstea porea 33615',
+                    }],
+                }],
+            }])
+                .pipe(ezs('affAlign'))
+                .on('data', (data) => {
+                    res = [...res, data];
+                })
+                .on('end', () => {
+                    expect(res).toHaveLength(1);
+                    expect(res).toEqual([{
+                        authors: [{
+                            affiliations: [{
+                                address: 'irstea porea 33615',
+                                conditorRnsr: ['200310864A'],
+                            }],
+                        }],
+                    }]);
+                    done();
+                });
+        });
     });
 
     describe('intitule', () => {
@@ -371,6 +431,34 @@ describe('co-aff-align', () => {
                             affiliations: [{
                                 address: 'POREA',
                                 conditorRnsr: [],
+                            }],
+                        }],
+                    }]);
+                    done();
+                });
+        });
+
+        it('should find the conditorRnsr in lowercase', (done) => {
+            let res = [];
+            from([{
+                authors: [{
+                    affiliations: [{
+                        address: 'pluridisciplinarité au service de l\'observation et de la recherche en environnement'
+                            + ' et astronomie 33615 irstea',
+                    }],
+                }],
+            }])
+                .pipe(ezs('affAlign'))
+                .on('data', (data) => {
+                    res = [...res, data];
+                })
+                .on('end', () => {
+                    expect(res).toEqual([{
+                        authors: [{
+                            affiliations: [{
+                                address: 'pluridisciplinarité au service de l\'observation et de la recherche en'
+                                    + ' environnement et astronomie 33615 irstea',
+                                conditorRnsr: ['200310864A'],
                             }],
                         }],
                     }]);


### PR DESCRIPTION
Pour pouvoir trouver plus d'affiliations dans le RNSR, on va rendre la recherche de chaînes insensible à la casse.